### PR TITLE
transport: enable virtiofs and vhost-user-fs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,23 +26,23 @@ libc = ">=0.2.68"
 log = ">=0.4.6"
 nix = "0.22"
 #ringbahn = { version = "0.0.0-experimental.3", optional = true }
-vmm-sys-util = { version = "0.8", optional = true }
-vm-memory = "0.6"
-#vm-virtio = { git = "https://github.com/cloud-hypervisor/vm-virtio.git", branch = "dragonball", optional = true }
-#vhost = { version = "0.1", optional = true }
+vmm-sys-util = { version = ">=0.8", optional = true }
+vm-memory = { version = "0.6", features = ["backend-atomic"] }
+virtio-queue = { git = "https://github.com/rust-vmm/vm-virtio", rev = "6013dd9", optional = true }
+vhost = { version = "0.2", features = ["vhost-user-slave"], optional = true }
 
 [dev-dependencies]
 futures = { version = "0.3.0", features = ["thread-pool"]}
 stderrlog = "0.4"
-vmm-sys-util = "0.8"
-vm-memory = { version = "0.6", features = ["backend-mmap"] }
+vmm-sys-util = ">=0.8"
+vm-memory = { version = "0.6", features = ["backend-mmap", "backend-atomic"] }
 
 [features]
 default = ["fusedev"]
 #async-io = ["async-trait", "futures", "iou", "ringbahn"]
 fusedev = ["vmm-sys-util"]
-#virtiofs = ["vm-virtio"]
-#vhost-user-fs = ["virtiofs", "vhost-rs/vhost-user-slave"]
+virtiofs = ["virtio-queue"]
+vhost-user-fs = ["virtiofs", "vhost"]
 
 [patch."registry+https://github.com/rust-lang/crates.io-index"]
 #ringbahn = { git = "https://github.com/jiangliu/ringbahn.git", branch = "enhance", optional = true }

--- a/Makefile
+++ b/Makefile
@@ -2,14 +2,20 @@ current_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 build:
 	cargo build --features="fusedev"
+	cargo build --features="virtiofs"
+	cargo build --features="vhost-user-fs"
 
 check: build
 	cargo fmt -- --check
 	cargo clippy --features="fusedev" -- -Dclippy::all
+	cargo clippy --features="virtiofs" -- -Dclippy::all
+	cargo clippy --features="vhost-user-fs" -- -Dclippy::all
+	cargo test --features="virtiofs" -- --nocapture --skip integration
 	cargo test --features="fusedev" -- --nocapture --skip integration
+	cargo test --features="vhost-user-fs" -- --nocapture --skip integration
 
 smoke: check
 	cargo test --features="fusedev" -- --nocapture
 
 docker-smoke:
-	docker run --rm --privileged -v ${current_dir}:/fuse-rs rust:slim sh -c "apt update;apt install -y make; rustup component add clippy rustfmt; cd /fuse-rs; make smoke"
+	docker run --rm --privileged -v ${current_dir}:/fuse-rs rust:1.52.1 sh -c "rustup component add clippy rustfmt; cd /fuse-rs; make smoke"

--- a/src/api/server/mod.rs
+++ b/src/api/server/mod.rs
@@ -162,6 +162,7 @@ pub trait MetricsHook {
 }
 
 struct SrvContext<'a, F, D: AsyncDrive = AsyncDriver, S: BitmapSlice = ()> {
+    #[allow(dead_code)]
     drive: Option<D>,
     in_header: InHeader,
     context: Context,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,11 +50,7 @@ extern crate bitflags;
 extern crate libc;
 #[macro_use]
 extern crate log;
-#[cfg(feature = "vhost-user-fs")]
-extern crate vhost;
 extern crate vm_memory;
-#[cfg(feature = "virtiofs")]
-extern crate vm_virtio;
 
 use std::ffi::{CStr, FromBytesWithNulError};
 use std::io::ErrorKind;

--- a/tests/example/mod.rs
+++ b/tests/example/mod.rs
@@ -2,5 +2,5 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(feature = "fusedev")]
+#[cfg(all(feature = "fusedev", not(feature = "virtiofs")))]
 pub(crate) mod passthroughfs;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,13 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 
-#[cfg(feature = "fusedev")]
+#[cfg(all(feature = "fusedev", not(feature = "virtiofs")))]
 #[macro_use]
 extern crate log;
 
 mod example;
 
-#[cfg(feature = "fusedev")]
+#[cfg(all(feature = "fusedev", not(feature = "virtiofs")))]
 mod fusedev_tests {
     extern crate stderrlog;
 


### PR DESCRIPTION
Bring back virtiofs and vhost-user-fs support so that consumers can use
the latest code to run virtiofs and vhost-user-fs.
